### PR TITLE
Next SUSE Manager version is 4.1.0, not 4.2.0

### DIFF
--- a/package/skelcd-control-suse-manager-proxy.changes
+++ b/package/skelcd-control-suse-manager-proxy.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed Nov 27 17:22:05 UTC 2019 - Julio González Gil <jgonzalez@suse.com>
+
+- SUSE Manager version 4.1.0
+
+-------------------------------------------------------------------
 Thu Oct 17 11:02:19 UTC 2019 - Josef Reidinger <jreidinger@suse.com>
 
 - Skip the registration step on the online and offline installation

--- a/package/skelcd-control-suse-manager-proxy.spec
+++ b/package/skelcd-control-suse-manager-proxy.spec
@@ -52,7 +52,7 @@ Provides:       system-installation() = SUSE-Manager-Proxy
 
 Url:            https://github.com/yast/skelcd-control-suse-manager-proxy
 AutoReqProv:    off
-Version:        4.2.0
+Version:        4.1.0
 Release:        0
 Summary:        SUSE Manager Proxy control file needed for installation
 License:        MIT


### PR DESCRIPTION
We need this at SUSE:SLE-15-SP2:GA ASAP, for SUSE Manager 4.1 Alpha1.