### PR TITLE
Added default preselected modules in offline installation (jsc#SLE-8040)

### DIFF
--- a/package/installation.suse-manager-proxy.xsl
+++ b/package/installation.suse-manager-proxy.xsl
@@ -203,4 +203,19 @@ textdomain="control"
         <xsl:apply-templates/>
       </xsl:copy>
   </xsl:template>
+
+  <!-- add a new "software/default_modules" section just after the "textdomain" -->
+  <xsl:template xml:space="preserve" match="n:textdomain">
+    <xsl:copy>
+      <xsl:apply-templates/>
+    </xsl:copy>
+    <software>
+      <xsl:comment> the default preselected modules in offline installation </xsl:comment>
+      <default_modules config:type="list">
+        <default_module>sle-module-basesystem</default_module>
+        <default_module>sle-module-server-applications</default_module>
+      </default_modules>
+    </software>
+  </xsl:template>
+
 </xsl:stylesheet>

--- a/package/skelcd-control-suse-manager-proxy.changes
+++ b/package/skelcd-control-suse-manager-proxy.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Feb 26 15:40:12 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
+
+- Added default preselected modules in offline installation
+  (jsc#SLE-8040)
+
+-------------------------------------------------------------------
 Wed Nov 27 17:22:05 UTC 2019 - Julio González Gil <jgonzalez@suse.com>
 
 - SUSE Manager version 4.1.0 (bsc#1157988)


### PR DESCRIPTION
- Added the default preselected modules in offline installation
- Related to https://jira.suse.com/browse/SLE-8040 and https://jira.suse.com/browse/SLE-11455
- Note: no version bump, see [this comment](https://github.com/yast/skelcd-control-suse-manager-proxy/blob/master/package/skelcd-control-suse-manager-proxy.spec#L55), I will submit the package manually.