### PR TITLE
Added BuildIgnore

### DIFF
--- a/package/skelcd-control-suse-manager-proxy.spec
+++ b/package/skelcd-control-suse-manager-proxy.spec
@@ -42,6 +42,14 @@ BuildRequires:  yast2-installation-control >= 4.1.5
 BuildRequires: skelcd-control-SLES >= 15.2.0
 BuildRequires: diffutils
 
+# for building we do not need all skelcd-control-SLES dependencies
+#!BuildIgnore: yast2-registration yast2-theme yast2 autoyast2 yast2-add-on yast2-buildtools
+#!BuildIgnore: yast2-devtools yast2-fcoe-client yast2-firewall yast2-installation
+#!BuildIgnore: yast2-iscsi-client yast2-kdump yast2-multipath yast2-network yast2-nfs-client
+#!BuildIgnore: yast2-ntp-client yast2-proxy yast2-services-manager yast2-configuration-management
+#!BuildIgnore: yast2-packager yast2-slp yast2-trans-stats yast2-tune yast2-update
+#!BuildIgnore: yast2-users yast2-x11 rubygem(%{rb_default_ruby_abi}:byebug) yast2-rdp
+
 # Use FHS compliant path
 Requires:       yast2 >= 4.1.41
 


### PR DESCRIPTION
- Ignore not needed packages
- Advantages:
  - Faster rebuilds (less packages needed in build root)
  - Less rebuilds (an YaST package update does not trigger rebuild)