### PR TITLE
Remove an RPM macro from comment

### DIFF
--- a/package/skelcd-control-suse-manager-proxy.spec
+++ b/package/skelcd-control-suse-manager-proxy.spec
@@ -48,7 +48,7 @@ BuildRequires:  skelcd-control-SLES >= 15.2.0
 #!BuildIgnore: yast2-iscsi-client yast2-kdump yast2-multipath yast2-network yast2-nfs-client
 #!BuildIgnore: yast2-ntp-client yast2-proxy yast2-services-manager yast2-configuration-management
 #!BuildIgnore: yast2-packager yast2-slp yast2-trans-stats yast2-tune yast2-update
-#!BuildIgnore: yast2-users yast2-x11 rubygem(%{rb_default_ruby_abi}:byebug) yast2-rdp
+#!BuildIgnore: yast2-users yast2-x11 yast2-rdp
 
 # Use FHS compliant path
 Requires:       yast2 >= 4.1.41


### PR DESCRIPTION
It caused a failure in Jenkins https://ci.suse.de/job/yast-skelcd-control-suse-manager-proxy-master/14/console:

```
[    9s] RPM build errors:
[    9s]     Macro expanded in comment on line 51: %{rb_default_ruby_abi}:byebug) yast2-rdp
[    9s] 
[    9s]     line 56: Invalid version (double separator '-'): SUSE-Manager-Proxy: Provides:       system-installation() = SUSE-Manager-Proxy
[    9s]     line 84: Invalid version (double separator '-'): SUSE-Manager-Retail-Branch-Server: Provides:       system-installation() = SUSE-Manager-Retail-Branch-Server
```

Removing that `BuildIgnore` should not hurt, I guess the byebug gem is not updated that often so the unnecessary rebuilds will happen only rarely.