### PR TITLE
Adapt to simplified workflow

### DIFF
--- a/package/skelcd-control-suse-manager-proxy.changes
+++ b/package/skelcd-control-suse-manager-proxy.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Dec  3 11:22:50 UTC 2021 - David Diaz <dgonzalez@suse.com>
+
+- Update dependency on skelcd-control-SLES to version 15.4.1 to
+  remove the registration step (bsc#1193311).
+- 4.3.1
+
+-------------------------------------------------------------------
 Tue Oct 19 08:26:10 UTC 2021 - Julio González Gil <jgonzalez@suse.com>
 
 - Version 4.3.0

--- a/package/skelcd-control-suse-manager-proxy.spec
+++ b/package/skelcd-control-suse-manager-proxy.spec
@@ -62,7 +62,7 @@ Provides:       system-installation() = SUSE-Manager-Proxy
 URL:            https://github.com/yast/skelcd-control-suse-manager-proxy
 AutoReqProv:    off
 # IMPORTANT: This needs to be 4.3.0 as it is the SUSE Manager version!
-Version:        4.3.0
+Version:        4.3.1
 Release:        0
 Summary:        SUSE Manager Proxy control file needed for installation
 License:        MIT

--- a/package/skelcd-control-suse-manager-proxy.spec
+++ b/package/skelcd-control-suse-manager-proxy.spec
@@ -38,9 +38,10 @@ BuildRequires:  libxml2-tools
 # Added skelcd macros
 BuildRequires:  yast2-installation-control >= 4.1.5
 
-# Original SLES control file (skip registration)
+# Original SLES control file
+# (simplified workflow - https://github.com/yast/skelcd-control-SLES/pull/142)
 BuildRequires:  diffutils
-BuildRequires:  skelcd-control-SLES >= 15.2.0
+BuildRequires:  skelcd-control-SLES >= 15.4.1
 
 # for building we do not need all skelcd-control-SLES dependencies
 #!BuildIgnore: yast2-registration yast2-theme yast2 autoyast2 yast2-add-on yast2-buildtools


### PR DESCRIPTION
## Problem

The installation workflow has been simplified (see https://github.com/yast/skelcd-control-leanos/pull/83, https://github.com/yast/skelcd-control-leanos/pull/84, and https://github.com/yast/skelcd-control-SLES/pull/141) but the dependency of this control file in skelcd-control-SLES has not been updated yet, which makes possible to get the registration step twice. See https://bugzilla.suse.com/show_bug.cgi?id=1193311.

## Solution

Update dependency on skelcd-control-SLES to 15.4.1

---

### :warning: NOTE for reviewers :warning:

~~Please, pay special attention to this PR since I really don't know if this product will have a version based on SP4 or not. Thus, I kept the version bump in 4.3.x, which leads me to think that the PR itself makes no sense.~~

See https://github.com/yast/skelcd-control-suse-manager-proxy/pull/19#pullrequestreview-822610870
