### PR TITLE
Adapt the package for SUSE Manager 4.4

### DIFF
--- a/package/skelcd-control-suse-manager-proxy.changes
+++ b/package/skelcd-control-suse-manager-proxy.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Nov  7 12:32:34 UTC 2022 - Julio González Gil <jgonzalez@suse.com>
+
+- Version 4.4.0
+  * SUSE Manager version 4.4.0 (bsc#1206557)
+
+-------------------------------------------------------------------
 Wed Apr 06 13:24:58 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Bump version to 4.5.0 (bsc#1198109)

--- a/package/skelcd-control-suse-manager-proxy.spec
+++ b/package/skelcd-control-suse-manager-proxy.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package skelcd-control-suse-manager-proxy
 #
-# Copyright (c) 2021 SUSE LLC
+# Copyright (c) 2022 SUSE LLC
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -41,7 +41,7 @@ BuildRequires:  yast2-installation-control >= 4.1.5
 # Original SLES control file
 # (simplified workflow - https://github.com/yast/skelcd-control-SLES/pull/142)
 BuildRequires:  diffutils
-BuildRequires:  skelcd-control-SLES >= 15.4.1
+BuildRequires:  skelcd-control-SLES >= 15.5.0
 
 # for building we do not need all skelcd-control-SLES dependencies
 #!BuildIgnore: yast2-registration yast2-theme yast2 autoyast2 yast2-add-on yast2-buildtools
@@ -61,8 +61,8 @@ Provides:       system-installation() = SUSE-Manager-Proxy
 
 URL:            https://github.com/yast/skelcd-control-suse-manager-proxy
 AutoReqProv:    off
-# IMPORTANT: This needs to be 4.3.0 as it is the SUSE Manager version!
-Version:        4.3.1
+# IMPORTANT: This needs to be 4.4.0 as it is the SUSE Manager version!
+Version:        4.4.0
 Release:        0
 Summary:        SUSE Manager Proxy control file needed for installation
 License:        MIT


### PR DESCRIPTION
## Problem

*Short description of the original problem.*

The package was not adapted for SUSE Manager 4.4 and SLE15SP5

## Solution

Fix the SPEC to be version 4.4.0, and require SLE15SP5


## Testing

- *Added a new unit test*: No
- *Tested manually*: Not really, skelcd does not even build at https://build.suse.de/package/show/SUSE:SLE-15-SP5:GA/skelcd-control-suse-manager-proxy, so I if I branch it it won't build either, and I am not sure how to test it.

## Screenshots

*If the fix affects the UI attach some screenshots here.*

I guess it will change the version you see at the Unified installer, but no idea of how to check it.

